### PR TITLE
Add upper bound to either and lower bound to time

### DIFF
--- a/ical.cabal
+++ b/ical.cabal
@@ -21,10 +21,10 @@ library
                      , attoparsec
                      , base >= 4.7 && < 5
                      , containers
-                     , either
+                     , either < 5
                      , mtl
                      , text
-                     , time
+                     , time >= 1.5
                      , transformers
   default-language:    Haskell2010
 


### PR DESCRIPTION
The upper bound on either is necessary to build
The lower bound on time makes the build successful on GHC 7.8

As a hackage trustee, I have made this change as a metadata revision to version 0.0.1 on hackage.